### PR TITLE
Fixed explosive gun mod issue

### DIFF
--- a/src/main/java/com/cravencraft/bloodybits/events/BloodyBitsEvents.java
+++ b/src/main/java/com/cravencraft/bloodybits/events/BloodyBitsEvents.java
@@ -12,6 +12,7 @@ import com.cravencraft.bloodybits.network.messages.EntityMessage;
 import com.cravencraft.bloodybits.registries.EntityRegistry;
 import com.cravencraft.bloodybits.utils.BloodyBitsUtils;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
@@ -162,10 +163,10 @@ public class BloodyBitsEvents {
      */
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void creeperExplosionEvent(ExplosionEvent event) {
-        LivingEntity entity = event.getExplosion().getIndirectSourceEntity();
+        Entity entity = event.getExplosion().getDirectSourceEntity();
 
-        if (entity != null && !event.isCanceled()) {
-            createBloodSpray(entity, event.getExplosion().getDamageSource(), 15, false);
+        if (entity instanceof LivingEntity livEnt && !event.isCanceled()) {
+            createBloodSpray(livEnt, event.getExplosion().getDamageSource(), 15, false);
         }
     }
 


### PR DESCRIPTION
Hi. Fixed explosive gun mod issue by replacing `getIndirectSource()` in explosive event with `getDirectSource()`. This way it will work for creepers, but won't for guns and other stuff
P.S.: Also your license on CurseForge is ARR while on GitHub it's MIT. Is it intended?