### PR TITLE
Fix NullPointerException: Cannot read field "f_19326_" because "this.f_20958_" is null

### DIFF
--- a/src/main/java/com/cravencraft/bloodybits/mixins/LivingEntityMixin.java
+++ b/src/main/java/com/cravencraft/bloodybits/mixins/LivingEntityMixin.java
@@ -61,8 +61,7 @@ public abstract class LivingEntityMixin extends Entity {
         if (this.self != null) {
             String entityId = (this.toString().contains("Player")) ? "player" : this.getEncodeId();
             if (CommonConfig.deathBloodExplosion() && !CommonConfig.blackListEntities().contains(entityId)) {
-                assert this.lastDamageSource != null;
-                if (!CommonConfig.blackListDamageSources().contains(this.lastDamageSource.msgId)) {
+                if (this.lastDamageSource != null && !CommonConfig.blackListDamageSources().contains(this.lastDamageSource.msgId)) {
                     this.createBloodExplosion();
                 }
             }


### PR DESCRIPTION
Crash report: [crash-2025-03-28_17.08.37-server.txt](https://github.com/user-attachments/files/19504451/crash-2025-03-28_17.08.37-server.txt)

The assertion failes sometimes, so it should be checked before access its field.