### PR TITLE
Prevent divide-by-zero error

### DIFF
--- a/src/main/java/com/cravencraft/bloodybits/events/BloodyBitsEvents.java
+++ b/src/main/java/com/cravencraft/bloodybits/events/BloodyBitsEvents.java
@@ -93,6 +93,10 @@ public class BloodyBitsEvents {
 
                 int mod = (int) (remainingHealthPercentage * 1000);
 
+                if (mod == 0 || entity.tickCount == 0) {
+                    return;
+                }
+
                 if (entity.tickCount % mod == 0) {
                     createBloodSpray(entity, entity.damageSources().genericKill(), 1, true);
                 }


### PR DESCRIPTION
This fixes an unreproducable crash that I've encountered where the modulus operation crashes the server due to a divide-by-zero. No matter what I've tried, I cannot find a reproducable setup for this crash.

I'm not entirely certain what causes this - whether it's the `mod` or `tickCount` being zero, or if floating-point errors are at play, but checking if either are equal to zero before running the modulus prevents this error entirely.